### PR TITLE
Update MethodCallHandler.kt

### DIFF
--- a/android/src/main/kotlin/ru/innim/flutter_login_vk/MethodCallHandler.kt
+++ b/android/src/main/kotlin/ru/innim/flutter_login_vk/MethodCallHandler.kt
@@ -106,7 +106,7 @@ class MethodCallHandler(private val context: Context, private val loginCallback:
         val count = list.size
         for (i in 0 until count) {
             val item = list[i]
-            val scope = VKScope.valueOf(item.uppercase(Locale.getDefault()))
+            val scope = VKScope.valueOf(item.uppercase())
             vkScopes.add(scope)
         }
         return vkScopes


### PR DESCRIPTION
Locale.getDefault() causes exception when the system language is Turkish language.