### PR TITLE
Fix root view controller acquiring on iOS

### DIFF
--- a/ios/Classes/SwiftFlutterLoginVkPlugin.swift
+++ b/ios/Classes/SwiftFlutterLoginVkPlugin.swift
@@ -185,10 +185,14 @@ public class SwiftFlutterLoginVkPlugin: NSObject, FlutterPlugin {
 class VkUIDelegate : NSObject, VKSdkUIDelegate {
     private var rootViewController: UIViewController? {
         get {
-            if let vc = UIApplication.shared.delegate?.window??.rootViewController {
+            if
+                #available(iOS 13.0, *),
+                let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                let vc = scene.windows.first(where: {window in window.isKeyWindow})?.rootViewController {
                 return vc
             }
-            return (UIApplication.shared.connectedScenes.first as? UIWindowScene)?.keyWindow?.rootViewController
+            let app = UIApplication.shared
+            return app.delegate?.window??.rootViewController
         }
     }
     

--- a/ios/Classes/SwiftFlutterLoginVkPlugin.swift
+++ b/ios/Classes/SwiftFlutterLoginVkPlugin.swift
@@ -187,8 +187,14 @@ class VkUIDelegate : NSObject, VKSdkUIDelegate {
         get {
             if
                 #available(iOS 13.0, *),
-                let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-                let vc = scene.windows.first(where: {window in window.isKeyWindow})?.rootViewController {
+                let vc = UIApplication.shared.connectedScenes
+                    .compactMap({ $0 as? UIWindowScene })
+                    .filter({ $0.activationState == .foregroundActive || $0.activationState == .foregroundInactive })
+                    .flatMap({ $0.windows })
+                    .filter({ $0.isKeyWindow })
+                    .compactMap({ $0.rootViewController })
+                    .first
+            {
                 return vc
             }
             let app = UIApplication.shared

--- a/ios/Classes/SwiftFlutterLoginVkPlugin.swift
+++ b/ios/Classes/SwiftFlutterLoginVkPlugin.swift
@@ -185,8 +185,10 @@ public class SwiftFlutterLoginVkPlugin: NSObject, FlutterPlugin {
 class VkUIDelegate : NSObject, VKSdkUIDelegate {
     private var rootViewController: UIViewController? {
         get {
-            let app = UIApplication.shared
-            return app.delegate?.window??.rootViewController
+            if let vc = UIApplication.shared.delegate?.window??.rootViewController {
+                return vc
+            }
+            return (UIApplication.shared.connectedScenes.first as? UIWindowScene)?.keyWindow?.rootViewController
         }
     }
     


### PR DESCRIPTION
This plugin doesn't work on recent versions of Flutter on iOS. The root cause is that https://github.com/Innim/flutter_login_vk/issues/51 is not done yet. So this hack should make this plugin work again until migration to scene-based lifecycle is done